### PR TITLE
Go runtime: Change misMatched to mismatched.

### DIFF
--- a/runtime/Go/src/antlr4/ErrorStrategy.go
+++ b/runtime/Go/src/antlr4/ErrorStrategy.go
@@ -185,7 +185,7 @@ func (this *DefaultErrorStrategy) Recover(recognizer Parser, e RecognitionExcept
 // <p><strong>ORIGINS</strong></p>
 //
 // <p>Previous versions of ANTLR did a poor job of their recovery within loops.
-// A single misMatch token or missing token would force the parser to bail
+// A single mismatch token or missing token would force the parser to bail
 // out of the entire rules surrounding the loop. So, for rule</p>
 //
 // <pre>
@@ -299,7 +299,7 @@ func (this *DefaultErrorStrategy) ReportNoViableAlternative(recognizer Parser, e
 // @param e the recognition exception
 //
 func (this *DefaultErrorStrategy) ReportInputMisMatch(recognizer Parser, e *InputMisMatchException) {
-	var msg = "misMatched input " + this.GetTokenErrorDisplay(e.offendingToken) +
+	var msg = "mismatched input " + this.GetTokenErrorDisplay(e.offendingToken) +
 		" expecting " + e.getExpectedTokens().StringVerbose(recognizer.GetLiteralNames(), recognizer.GetSymbolicNames(), false)
 	recognizer.NotifyErrorListeners(msg, e.offendingToken, e)
 }
@@ -326,7 +326,7 @@ func (this *DefaultErrorStrategy) ReportFailedPredicate(recognizer Parser, e *Fa
 // {@code recognizer} is in error recovery mode.
 //
 // <p>This method is called when {@link //singleTokenDeletion} identifies
-// single-token deletion as a viable recovery strategy for a misMatched
+// single-token deletion as a viable recovery strategy for a mismatched
 // input error.</p>
 //
 // <p>The default implementation simply returns if the handler is already in
@@ -355,7 +355,7 @@ func (this *DefaultErrorStrategy) ReportUnwantedToken(recognizer Parser) {
 // method returns, {@code recognizer} is in error recovery mode.
 //
 // <p>This method is called when {@link //singleTokenInsertion} identifies
-// single-token insertion as a viable recovery strategy for a misMatched
+// single-token insertion as a viable recovery strategy for a mismatched
 // input error.</p>
 //
 // <p>The default implementation simply returns if the handler is already in
@@ -377,7 +377,7 @@ func (this *DefaultErrorStrategy) ReportMissingToken(recognizer Parser) {
 	recognizer.NotifyErrorListeners(msg, t, nil)
 }
 
-// <p>The default implementation attempts to recover from the misMatched input
+// <p>The default implementation attempts to recover from the mismatched input
 // by using single token insertion and deletion as described below. If the
 // recovery attempt fails, this method panics an
 // {@link InputMisMatchException}.</p>
@@ -446,7 +446,7 @@ func (this *DefaultErrorStrategy) RecoverInline(recognizer Parser) Token {
 //
 // This method implements the single-token insertion inline error recovery
 // strategy. It is called by {@link //recoverInline} if the single-token
-// deletion strategy fails to recover from the misMatched input. If this
+// deletion strategy fails to recover from the mismatched input. If this
 // method returns {@code true}, {@code recognizer} will be in error recovery
 // mode.
 //
@@ -458,7 +458,7 @@ func (this *DefaultErrorStrategy) RecoverInline(recognizer Parser) Token {
 //
 // @param recognizer the parser instance
 // @return {@code true} if single-token insertion is a viable recovery
-// strategy for the current misMatched input, otherwise {@code false}
+// strategy for the current mismatched input, otherwise {@code false}
 //
 func (this *DefaultErrorStrategy) singleTokenInsertion(recognizer Parser) bool {
 	var currentSymbolType = recognizer.GetTokenStream().LA(1)
@@ -479,7 +479,7 @@ func (this *DefaultErrorStrategy) singleTokenInsertion(recognizer Parser) bool {
 
 // This method implements the single-token deletion inline error recovery
 // strategy. It is called by {@link //recoverInline} to attempt to recover
-// from misMatched input. If this method returns nil, the parser and error
+// from mismatched input. If this method returns nil, the parser and error
 // handler state will not have changed. If this method returns non-nil,
 // {@code recognizer} will <em>not</em> be in error recovery mode since the
 // returned token was a successful Match.
@@ -492,7 +492,7 @@ func (this *DefaultErrorStrategy) singleTokenInsertion(recognizer Parser) bool {
 //
 // @param recognizer the parser instance
 // @return the successfully Matched {@link Token} instance if single-token
-// deletion successfully recovers from the misMatched input, otherwise
+// deletion successfully recovers from the mismatched input, otherwise
 // {@code nil}
 //
 func (this *DefaultErrorStrategy) singleTokenDeletion(recognizer Parser) Token {
@@ -659,7 +659,7 @@ func (this *DefaultErrorStrategy) escapeWSAndQuote(s string) string {
 // In this case, for input "[]", LA(1) is ']' and in the set, so we would
 // not consume anything. After printing an error, rule c would
 // return normally. Rule b would not find the required '^' though.
-// At this point, it gets a misMatched token error and panics an
+// At this point, it gets a mismatched token error and panics an
 // exception (since LA(1) is not in the viable following token
 // set). The rule exception handler tries to recover, but finds
 // the same recovery set and doesn't consume anything. Rule b

--- a/runtime/Go/src/antlr4/Errors.go
+++ b/runtime/Go/src/antlr4/Errors.go
@@ -1,10 +1,8 @@
 package antlr4
 
-import ()
-
 // The root of the ANTLR exception hierarchy. In general, ANTLR tracks just
 //  3 kinds of errors: prediction errors, failed predicate errors, and
-//  misMatched input errors. In each case, the parser knows where it is
+//  mismatched input errors. In each case, the parser knows where it is
 //  in the input, where it is in the ATN, the rule invocation stack,
 //  and what kind of problem occurred.
 
@@ -173,7 +171,7 @@ type InputMisMatchException struct {
 	*BaseRecognitionException
 }
 
-// This signifies any kind of misMatched input exceptions such as
+// This signifies any kind of mismatched input exceptions such as
 // when the current input does not Match the expected token.
 //
 func NewInputMisMatchException(recognizer Parser) *InputMisMatchException {

--- a/runtime/Go/src/antlr4/Parser.go
+++ b/runtime/Go/src/antlr4/Parser.go
@@ -129,7 +129,7 @@ func (p *BaseParser) SetErrorHandler(e ErrorStrategy) {
 // @return the Matched symbol
 // @panics RecognitionException if the current input symbol did not Match
 // {@code ttype} and the error strategy could not recover from the
-// misMatched symbol
+// mismatched symbol
 
 func (p *BaseParser) Match(ttype int) Token {
 
@@ -175,7 +175,7 @@ func (p *BaseParser) Match(ttype int) Token {
 //
 // @return the Matched symbol
 // @panics RecognitionException if the current input symbol did not Match
-// a wildcard and the error strategy could not recover from the misMatched
+// a wildcard and the error strategy could not recover from the mismatched
 // symbol
 
 func (p *BaseParser) MatchWildcard() Token {


### PR DESCRIPTION
That seemed to be a find/replace accident. Apparently this change turns
the tests ...
- testTokenMismatch
- testTokenMismatch2
- testNoViableAltAvoidance
- testNoViableAlt
- testExprAmbiguity_2

... to green. Although I am not sure about testExprAmbiguity_2 as that
one doesn't have mis[Mm]atched in its output AFAICS.
