### PR TITLE
travis: install Go 1.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_install:
   - sudo apt-get install -qq nodejs
   - echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/3.12.1 main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
   - sudo apt-get install -qq mono-complete
-  
+  - curl -s https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz | sudo tar -C /usr/local -xzf -

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ before_install:
   - sudo apt-get install -qq nodejs
   - echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/3.12.1 main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
   - sudo apt-get install -qq mono-complete
-  - curl -s https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz | sudo tar -C /usr/local -xzf -
+  - eval "$(sudo gimme 1.6.2)"
+  - go version ; go env


### PR DESCRIPTION
As of now this should only work for github.com/pboyer/antlr4 due to go import paths.
