### PR TITLE
Sort values of BitSet.

### DIFF
--- a/runtime/Go/antlr/utils.go
+++ b/runtime/Go/antlr/utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"strings"
 	//	"regexp"
 	//	"bytes"
@@ -221,6 +222,7 @@ func (b *BitSet) values() []int {
 		ks[i] = k
 		i++
 	}
+	sort.Ints(ks)
 	return ks
 }
 


### PR DESCRIPTION
Instead of BitSet.String() I have fixed BitSet.values(). That feels cleaner to me. testExprAmbiguity_2 successfully ran about 50 times. 
