### PR TITLE
Sync go testsuite stg, switch off other langs.

### DIFF
--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -119,6 +119,8 @@
                     <argument>${basedir}/test</argument>
                     <argument>-templates</argument>
                     <argument>${basedir}/resources/org/antlr/v4/test/runtime/templates</argument>
+                    <argument>-target</argument> <!-- TODO remove this before merging with upstream! -->
+                    <argument>Go</argument> <!-- TODO remove this before merging with upstream! -->
                   </arguments>
                 </configuration>
               </execution>

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestCompositeParsers.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestCompositeParsers.java
@@ -62,17 +62,17 @@ public class TestCompositeParsers extends BaseTest {
 	@Test
 	public void testDelegatesSeeSameTokenType() throws Exception {
 		mkdir(parserpkgdir);
-		String slave_T =
-			"parser grammar T;\n" +
-			"tokens { C, B, A } // reverse order\n" +
-			"y : A {fmt.Println(\"T.y\")};";
-		writeFile(parserpkgdir, "T.g4", slave_T);
-
 		String slave_S =
 			"parser grammar S;\n" +
 			"tokens { A, B, C }\n" +
 			"x : A {fmt.Println(\"S.x\")};";
 		writeFile(parserpkgdir, "S.g4", slave_S);
+
+		String slave_T =
+			"parser grammar T;\n" +
+			"tokens { C, B, A } // reverse order\n" +
+			"y : A {fmt.Println(\"T.y\")};";
+		writeFile(parserpkgdir, "T.g4", slave_T);
 
 		StringBuilder grammarBuilder = new StringBuilder(598);
 		grammarBuilder.append("// The lexer will create rules to match letters a, b, c.\n");
@@ -207,16 +207,16 @@ public class TestCompositeParsers extends BaseTest {
 	@Test
 	public void testDelegatorInvokesFirstVersionOfDelegateRule() throws Exception {
 		mkdir(parserpkgdir);
-		String slave_T =
-			"parser grammar T;\n" +
-			"a : B {fmt.Println(\"T.a\")};";
-		writeFile(parserpkgdir, "T.g4", slave_T);
-
 		String slave_S =
 			"parser grammar S;\n" +
 			"a : b {fmt.Println(\"S.a\")};\n" +
 			"b : B;";
 		writeFile(parserpkgdir, "S.g4", slave_S);
+
+		String slave_T =
+			"parser grammar T;\n" +
+			"a : B {fmt.Println(\"T.a\")};";
+		writeFile(parserpkgdir, "T.g4", slave_T);
 
 		StringBuilder grammarBuilder = new StringBuilder(106);
 		grammarBuilder.append("grammar M;\n");
@@ -261,17 +261,17 @@ public class TestCompositeParsers extends BaseTest {
 	@Test
 	public void testDelegatorRuleOverridesDelegates() throws Exception {
 		mkdir(parserpkgdir);
-		String slave_T =
-			"parser grammar T;\n" +
-			"tokens { A }\n" +
-			"b : 'b' {fmt.Println(\"T.b\")};";
-		writeFile(parserpkgdir, "T.g4", slave_T);
-
 		String slave_S =
 			"parser grammar S;\n" +
 			"a : b {fmt.Println(\"S.a\")};\n" +
 			"b : 'b' ;";
 		writeFile(parserpkgdir, "S.g4", slave_S);
+
+		String slave_T =
+			"parser grammar T;\n" +
+			"tokens { A }\n" +
+			"b : 'b' {fmt.Println(\"T.b\")};";
+		writeFile(parserpkgdir, "T.g4", slave_T);
 
 		StringBuilder grammarBuilder = new StringBuilder(87);
 		grammarBuilder.append("grammar M;\n");

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestFullContextParsing.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestFullContextParsing.java
@@ -34,7 +34,7 @@ public class TestFullContextParsing extends BaseTest {
 	@Test
 	public void testAmbiguityNoLoop() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(218);
+		StringBuilder grammarBuilder = new StringBuilder(217);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("prog\n");
 		grammarBuilder.append("@init {p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);}\n");
@@ -154,7 +154,7 @@ public class TestFullContextParsing extends BaseTest {
 	@Test
 	public void testExprAmbiguity_1() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(293);
+		StringBuilder grammarBuilder = new StringBuilder(292);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s\n");
 		grammarBuilder.append("@init {p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);}\n");
@@ -184,7 +184,7 @@ public class TestFullContextParsing extends BaseTest {
 	@Test
 	public void testExprAmbiguity_2() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(293);
+		StringBuilder grammarBuilder = new StringBuilder(292);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s\n");
 		grammarBuilder.append("@init {p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);}\n");
@@ -216,7 +216,7 @@ public class TestFullContextParsing extends BaseTest {
 	@Test
 	public void testFullContextIF_THEN_ELSEParse_1() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(243);
+		StringBuilder grammarBuilder = new StringBuilder(242);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s \n");
 		grammarBuilder.append("@init {p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);}\n");
@@ -242,7 +242,7 @@ public class TestFullContextParsing extends BaseTest {
 	@Test
 	public void testFullContextIF_THEN_ELSEParse_2() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(243);
+		StringBuilder grammarBuilder = new StringBuilder(242);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s \n");
 		grammarBuilder.append("@init {p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);}\n");
@@ -271,7 +271,7 @@ public class TestFullContextParsing extends BaseTest {
 	@Test
 	public void testFullContextIF_THEN_ELSEParse_3() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(243);
+		StringBuilder grammarBuilder = new StringBuilder(242);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s \n");
 		grammarBuilder.append("@init {p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);}\n");
@@ -301,7 +301,7 @@ public class TestFullContextParsing extends BaseTest {
 	@Test
 	public void testFullContextIF_THEN_ELSEParse_4() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(243);
+		StringBuilder grammarBuilder = new StringBuilder(242);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s \n");
 		grammarBuilder.append("@init {p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);}\n");
@@ -332,7 +332,7 @@ public class TestFullContextParsing extends BaseTest {
 	@Test
 	public void testFullContextIF_THEN_ELSEParse_5() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(243);
+		StringBuilder grammarBuilder = new StringBuilder(242);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s \n");
 		grammarBuilder.append("@init {p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);}\n");
@@ -366,7 +366,7 @@ public class TestFullContextParsing extends BaseTest {
 	@Test
 	public void testFullContextIF_THEN_ELSEParse_6() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(243);
+		StringBuilder grammarBuilder = new StringBuilder(242);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s \n");
 		grammarBuilder.append("@init {p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);}\n");
@@ -400,7 +400,7 @@ public class TestFullContextParsing extends BaseTest {
 	@Test
 	public void testLoopsSimulateTailRecursion() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(317);
+		StringBuilder grammarBuilder = new StringBuilder(316);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("prog\n");
 		grammarBuilder.append("@init {p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);}\n");

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestLexerExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestLexerExec.java
@@ -4625,7 +4625,7 @@ public class TestLexerExec extends BaseTest {
 	public void testPositionAdjustingLexer() throws Exception {
 		mkdir(parserpkgdir);
 
-		StringBuilder grammarBuilder = new StringBuilder(3037);
+		StringBuilder grammarBuilder = new StringBuilder(3029);
 		grammarBuilder.append("lexer grammar PositionAdjustingLexer;\n");
 		grammarBuilder.append("\n");
 		grammarBuilder.append("@members {\n");

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
@@ -12,7 +12,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testBasic() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(569);
+		StringBuilder grammarBuilder = new StringBuilder(567);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -64,7 +64,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testLR() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(743);
+		StringBuilder grammarBuilder = new StringBuilder(742);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -124,7 +124,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testLRWithLabels() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(734);
+		StringBuilder grammarBuilder = new StringBuilder(733);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -183,7 +183,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testRuleGetters_1() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(768);
+		StringBuilder grammarBuilder = new StringBuilder(767);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -239,7 +239,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testRuleGetters_2() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(768);
+		StringBuilder grammarBuilder = new StringBuilder(767);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -295,7 +295,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testTokenGetters_1() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(699);
+		StringBuilder grammarBuilder = new StringBuilder(698);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -350,7 +350,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testTokenGetters_2() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(699);
+		StringBuilder grammarBuilder = new StringBuilder(698);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParserErrors.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParserErrors.java
@@ -46,13 +46,14 @@ public class TestParserErrors extends BaseTest {
 	@Test
 	public void testContextListGetters() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(205);
+		StringBuilder grammarBuilder = new StringBuilder(215);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::members{\n");
 		grammarBuilder.append("func foo() {\n");
-		grammarBuilder.append("	SContext s = null;\n");
-		grammarBuilder.append("	List<? extends AContext> a = s.a();\n");
-		grammarBuilder.append("	List<? extends BContext> b = s.b();\n");
+		grammarBuilder.append("//TODO\n");
+		grammarBuilder.append("//SContext s = null;\n");
+		grammarBuilder.append("//List<? extends AContext> a = s.A();\n");
+		grammarBuilder.append("//List<? extends BContext> b = s.B();\n");
 		grammarBuilder.append("}\n");
 		grammarBuilder.append("}\n");
 		grammarBuilder.append("s : (a | b)+;\n");

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParserExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParserExec.java
@@ -590,7 +590,7 @@ public class TestParserExec extends BaseTest {
 		grammarBuilder.append("  return true\n");
 		grammarBuilder.append("}\n");
 		grammarBuilder.append("}\n");
-		grammarBuilder.append("a : {Property()}? ID {fmt.Println(\"valid\")}\n");
+		grammarBuilder.append("a : {$parser.Property()}? ID {fmt.Println(\"valid\")}\n");
 		grammarBuilder.append("  ;\n");
 		grammarBuilder.append("ID : 'a'..'z'+ ;\n");
 		grammarBuilder.append("WS : (' '|'\\n') -> skip ;");
@@ -611,7 +611,7 @@ public class TestParserExec extends BaseTest {
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s : stmt EOF ;\n");
 		grammarBuilder.append("stmt : ifStmt | ID;\n");
-		grammarBuilder.append("ifStmt : 'if' ID stmt ('else' stmt | { p.GetTokenStream().LA(1)!=TParserELSE }?);\n");
+		grammarBuilder.append("ifStmt : 'if' ID stmt ('else' stmt | { p.GetTokenStream().LA(1)!=TParser.ELSE }?);\n");
 		grammarBuilder.append("ELSE : 'else';\n");
 		grammarBuilder.append("ID : [a-zA-Z]+;\n");
 		grammarBuilder.append("WS : [ \\n\\t]+ -> skip;");

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestSemPredEvalParser.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestSemPredEvalParser.java
@@ -12,7 +12,7 @@ public class TestSemPredEvalParser extends BaseTest {
 	@Test
 	public void test2UnpredicatedAlts() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(300);
+		StringBuilder grammarBuilder = new StringBuilder(299);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s : {p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);} a ';' a; // do 2x: once in ATN, next in DFA\n");
 		grammarBuilder.append("a : ID {fmt.Println(\"alt 1\")}\n");
@@ -42,7 +42,7 @@ public class TestSemPredEvalParser extends BaseTest {
 	@Test
 	public void test2UnpredicatedAltsAndOneOrthogonalAlt() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(351);
+		StringBuilder grammarBuilder = new StringBuilder(350);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s : {p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);} a ';' a ';' a;\n");
 		grammarBuilder.append("a : INT {fmt.Println(\"alt 1\")}\n");
@@ -100,7 +100,7 @@ public class TestSemPredEvalParser extends BaseTest {
 	@Test
 	public void testActionsHidePredsInGlobalFOLLOW() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(279);
+		StringBuilder grammarBuilder = new StringBuilder(275);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@members {\n");
 		grammarBuilder.append("func pred(v bool) bool {\n");
@@ -148,7 +148,7 @@ public class TestSemPredEvalParser extends BaseTest {
 	@Test
 	public void testDepedentPredsInGlobalFOLLOW() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(302);
+		StringBuilder grammarBuilder = new StringBuilder(298);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@members {\n");
 		grammarBuilder.append("func pred(v bool) bool {\n");
@@ -300,7 +300,7 @@ public class TestSemPredEvalParser extends BaseTest {
 		grammarBuilder.append("@after {fmt.Println($ctx.ToStringTree(nil,p))}\n");
 		grammarBuilder.append("  : para para EOF ;\n");
 		grammarBuilder.append("para: paraContent NL NL ;\n");
-		grammarBuilder.append("paraContent : ('s'|'x'|{p.GetTokenStream().LA(2)!=TParserNL}? NL)+ ;\n");
+		grammarBuilder.append("paraContent : ('s'|'x'|{p.GetTokenStream().LA(2)!=TParser.NL}? NL)+ ;\n");
 		grammarBuilder.append("NL : '\\n' ;\n");
 		grammarBuilder.append("s : 's' ;\n");
 		grammarBuilder.append("X : 'x' ;");
@@ -330,7 +330,7 @@ public class TestSemPredEvalParser extends BaseTest {
 		grammarBuilder.append("@after {fmt.Println($ctx.ToStringTree(nil,p))}\n");
 		grammarBuilder.append("  : para para EOF ;\n");
 		grammarBuilder.append("para: paraContent NL NL ;\n");
-		grammarBuilder.append("paraContent : ('s'|'x'|{p.GetTokenStream().LA(2)!=TParserNL}? NL)+ ;\n");
+		grammarBuilder.append("paraContent : ('s'|'x'|{p.GetTokenStream().LA(2)!=TParser.NL}? NL)+ ;\n");
 		grammarBuilder.append("NL : '\\n' ;\n");
 		grammarBuilder.append("s : 's' ;\n");
 		grammarBuilder.append("X : 'x' ;");
@@ -447,7 +447,7 @@ public class TestSemPredEvalParser extends BaseTest {
 	@Test
 	public void testPredsInGlobalFOLLOW() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(273);
+		StringBuilder grammarBuilder = new StringBuilder(269);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@members {\n");
 		grammarBuilder.append("func pred(v bool) bool {\n");


### PR DESCRIPTION
Sync testsuite's go templates to the java source code and temporarily switch off code generation for other language targets than Go (it causes too much noise). 

_Do not pull, yet. I think this has a regression._ 

@willfaught In this diff I see a change that I vagely remember you have introduced. Maybe you have patched the Java source instead of its template? I'll put an inline comment in this PR. 
