### PR TITLE
Minor header comment rewording and formatting

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -1,5 +1,5 @@
 fileHeader(grammarFileName, ANTLRVersion) ::= <<
-// Generated from <grammarFileName; format="java-escape"> by ANTLR <ANTLRVersion>
+// Generated from <grammarFileName; format="java-escape"> by ANTLR <ANTLRVersion>.
 >>
 
 ParserFile(file, parser, namedActions) ::= <<

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -1,5 +1,6 @@
 fileHeader(grammarFileName, ANTLRVersion) ::= <<
 // Generated from <grammarFileName; format="java-escape"> by ANTLR <ANTLRVersion>.
+
 >>
 
 ParserFile(file, parser, namedActions) ::= <<


### PR DESCRIPTION
- Make the header comment full sentence
- Make the header comment a file comment, not package doc
