### PR TITLE
tool/Go: gofmt generated code.

### DIFF
--- a/tool/src/org/antlr/v4/codegen/target/GoTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/GoTarget.java
@@ -3,10 +3,15 @@ package org.antlr.v4.codegen.target;
 
 import org.antlr.v4.codegen.CodeGenerator;
 import org.antlr.v4.codegen.Target;
+import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.ast.GrammarAST;
+import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.StringRenderer;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
@@ -40,6 +45,9 @@ public class GoTarget extends Target {
 	/** Avoid grammar symbols in this set to prevent conflicts in gen'd code. */
 	private final Set<String> badWords = new HashSet<String>(goKeywords.length + goPredeclaredIdentifiers.length + 2);
 
+	private static final boolean DO_GOFMT = !Boolean.parseBoolean(System.getenv("ANTLR_GO_DISABLE_GOFMT"))
+			&& !Boolean.parseBoolean(System.getProperty("antlr.go.disable-gofmt"));
+
 	public GoTarget(CodeGenerator gen) {
 		super(gen, "Go");
 	}
@@ -62,6 +70,41 @@ public class GoTarget extends Target {
 		badWords.addAll(Arrays.asList(goPredeclaredIdentifiers));
 		badWords.add("rule");
 		badWords.add("parserRule");
+	}
+
+	@Override
+	protected void genFile(Grammar g, ST outputFileST, String fileName) {
+		super.genFile(g, outputFileST, fileName);
+		if (DO_GOFMT && !fileName.startsWith(".") /* criterion taken from gofmt */ && fileName.endsWith(".go")) {
+			gofmt(new File(getCodeGenerator().tool.getOutputDirectory(g.fileName), fileName));
+		}
+	}
+
+	private void gofmt(File fileName) {
+		// Optimistically run gofmt. If this fails, it doesn't matter at this point. Wait for termination though,
+		// because "gofmt -w" uses ioutil.WriteFile internally, which means it literally writes in-place with O_TRUNC.
+		// That could result in a race. (Why oh why doesn't it do tmpfile + rename?)
+		try {
+			ProcessBuilder gofmtBuilder = new ProcessBuilder("gofmt", "-w", "-s", fileName.getPath());
+			gofmtBuilder.redirectErrorStream(true);
+			Process gofmt = gofmtBuilder.start();
+			InputStream stdout = gofmt.getInputStream();
+			// TODO(wjkohnen): simplify to `while (stdout.Read() > 1) {}`
+			byte[] buf = new byte[1 << 10];
+			for (int l = 0; l > -1; l = stdout.read(buf)) {
+				// There should not be any output that exceeds the implicit output buffer. In normal ops there should be
+				// zero output. In case there is output, blocking and therefore killing the process is acceptable. This
+				// drains the buffer anyway to play it safe.
+
+				// dirty debug (change -w above to -d):
+				// System.err.write(buf, 0, l);
+			}
+			gofmt.waitFor();
+		} catch (IOException e) {
+			// Probably gofmt not in $PATH, in any case ignore.
+		} catch (InterruptedException forward) {
+			Thread.currentThread().interrupt();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
@pboyer @willfaught

Do you think, this is too smart? It would definitely be useful to have gofmt'd code, because generated code will end up in users' code repositories and gofmt'd code produces less noise there. But having this at this stage of development may make debugging confusing. 

I tried to change the templates according to Go coding style, but that is not entirely possible. That's why I've patched `genFile`.
