### PR TITLE
tool/Go: Add predefined identifiers to list of keywords.

### DIFF
--- a/tool/src/org/antlr/v4/codegen/target/GoTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/GoTarget.java
@@ -19,16 +19,26 @@ import java.util.Set;
  * */
 public class GoTarget extends Target {
 
-	protected static final String[] goKeywords = {
-        "break","default","func","interface","select",
-        "case","defer","go","map","struct",
-        "chan","else","goto","package","switch",
-        "const","fallthrough","if","range","type",
-        "continue","for","import","return","var"
-    };
+	private static final String[] goKeywords = {
+			"break", "default", "func", "interface", "select",
+			"case", "defer", "go", "map", "struct",
+			"chan", "else", "goto", "package", "switch",
+			"const", "fallthrough", "if", "range", "type",
+			"continue", "for", "import", "return", "var"
+	};
+
+	// predeclared identifiers https://golang.org/ref/spec#Predeclared_identifiers
+	private static final String[] goPredeclaredIdentifiers = {
+			"bool", "byte", "complex64", "complex128", "error", "float32", "float64",
+			"int", ",int8", "int16", "int32", "int64", "rune", "string",
+			"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
+			"true", "false", "iota", "nil",
+			"append", "cap", "close", "complex", "copy", "delete", "imag", "len",
+			"make", "new", "panic", "print", "println", "real", "recover"
+	};
 
 	/** Avoid grammar symbols in this set to prevent conflicts in gen'd code. */
-	protected final Set<String> badWords = new HashSet<String>();
+	private final Set<String> badWords = new HashSet<String>(goKeywords.length + goPredeclaredIdentifiers.length + 2);
 
 	public GoTarget(CodeGenerator gen) {
 		super(gen, "Go");
@@ -36,8 +46,8 @@ public class GoTarget extends Target {
 
     @Override
     public String getVersion() {
-        return "4.5.1";
-    }
+		return "4.5.2";
+	}
 
     public Set<String> getBadWords() {
 		if (badWords.isEmpty()) {
@@ -49,6 +59,7 @@ public class GoTarget extends Target {
 
 	protected void addBadWords() {
 		badWords.addAll(Arrays.asList(goKeywords));
+		badWords.addAll(Arrays.asList(goPredeclaredIdentifiers));
 		badWords.add("rule");
 		badWords.add("parserRule");
 	}


### PR DESCRIPTION
[Predefined indentifiers](https://golang.org/ref/spec#Predeclared_identifiers) such as `true` are not keywords in the strict sense (as they are in e.g. Java), but I guess we should still prevent colliding with them, should we not?

```
wjk@344df8db4881:tmp$ cat > test.go
package main

import "fmt"

func main() {
    true := false
    fmt.Printf("true: %t\n", true)
}
wjk@344df8db4881:tmp$ go run test.go 
true: false
```

TIL. :-O
