### PR TITLE
Fix test case build errors

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/csharp/CSharp.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/csharp/CSharp.test.stg
@@ -229,6 +229,10 @@ LL_EXACT_AMBIG_DETECTION() ::= <<Interpreter.PredictionMode = PredictionMode.LlE
 
 ParserToken(parser, token) ::= <%<parser>.<token>%>
 
+Production(p) ::= <%<p>%>
+
+Result(r) ::= <%<r>%>
+
 ParserPropertyMember() ::= <<
 @members {
 bool Property() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/go/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/go/Go.test.stg
@@ -194,7 +194,7 @@ StringList() ::= "[]string"
 
 BuildParseTrees() ::= "p.BuildParseTrees = true"
 
-BailErrorStrategy() ::= <%p.SetErrorHandler(p.NewBailErrorStrategy())%>
+BailErrorStrategy() ::= <%p.SetErrorHandler(antlr.NewBailErrorStrategy())%>
 
 ToStringTree(s) ::= <%<s>.ToStringTree(nil, p)%>
 
@@ -225,6 +225,10 @@ RuleInvocationStack() ::= "p.GetRuleInvocationStack(nil)"
 LL_EXACT_AMBIG_DETECTION() ::= <<p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);>>
 
 ParserToken(parser, token) ::= <%<parser><token>%>
+
+Production(p) ::= <%<p; format="cap">%>
+
+Result(r) ::= <%Get<r; format="cap">()%>
 
 ParserPropertyMember() ::= <<
 @members {
@@ -356,7 +360,7 @@ func NewLeafListener() *LeafListener {
 
 func (*LeafListener) ExitA(ctx *AContext) {
 	if ctx.GetChildCount() == 2 {
-		fmt.Printf("%s %s %s", ctx.INT(0)[0].GetSymbol().GetText(), ctx.INT(1)[0].GetSymbol().GetText(), ctx.INT(0)[0])
+		fmt.Printf("%s %s %s", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), ctx.AllINT())
 	} else {
 		fmt.Println(ctx.ID().GetSymbol())
 	}
@@ -374,9 +378,9 @@ func NewLeafListener() *LeafListener {
 
 func (*LeafListener) ExitA(ctx *AContext) {
 	if ctx.GetChildCount() == 2 {
-		fmt.Printf("%s %s %s", ctx.B(0)[0].GetStart().GetText(), ctx.B(1)[0].GetStart().GetText(), ctx.B(-1)[0].GetStart().GetText())
+		fmt.Printf("%s %s %s", ctx.B(0).GetStart().GetText(), ctx.B(1).GetStart().GetText(), ctx.AllB()[0].GetStart().GetText())
 	} else {
-		fmt.Println(ctx.B(0)[0].GetStart().GetText())
+		fmt.Println(ctx.B(0).GetStart().GetText())
 	}
 }
 >>
@@ -392,7 +396,7 @@ func NewLeafListener() *LeafListener {
 
 func (*LeafListener) ExitE(ctx *EContext) {
 	if ctx.GetChildCount() == 3 {
-		fmt.Printf("%s %s %s\n", ctx.E(0)[0].GetStart().GetText(), ctx.E(1)[0].GetStart().GetText(), ctx.E(-1)[0].GetStart().GetText())
+		fmt.Printf("%s %s %s\n", ctx.E(0).GetStart().GetText(), ctx.E(1).GetStart().GetText(), ctx.AllE()[0].GetStart().GetText())
 	} else {
 		fmt.Println(ctx.INT().GetSymbol().GetText())
 	}

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/java/Java.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/java/Java.test.stg
@@ -235,6 +235,10 @@ LL_EXACT_AMBIG_DETECTION() ::= <<_interp.setPredictionMode(PredictionMode.LL_EXA
 
 ParserToken(parser, token) ::= <%<parser>.<token>%>
 
+Production(p) ::= <%<p>%>
+
+Result(r) ::= <%<r>%>
+
 ParserPropertyMember() ::= <<
 @members {
 boolean Property() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/javascript/chrome/Chrome.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/javascript/chrome/Chrome.test.stg
@@ -235,6 +235,10 @@ LL_EXACT_AMBIG_DETECTION() ::= <<this._interp.predictionMode = antlr4.atn.Predic
 
 ParserToken(parser, token) ::= <%<parser>.<token>%>
 
+Production(p) ::= <%<p>%>
+
+Result(r) ::= <%<r>%>
+
 ParserPropertyMember() ::= <<
 @members {
 this.Property = function() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/javascript/explorer/Explorer.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/javascript/explorer/Explorer.test.stg
@@ -235,6 +235,10 @@ LL_EXACT_AMBIG_DETECTION() ::= <<this._interp.predictionMode = antlr4.atn.Predic
 
 ParserToken(parser, token) ::= <%<parser>.<token>%>
 
+Production(p) ::= <%<p>%>
+
+Result(r) ::= <%<r>%>
+
 ParserPropertyMember() ::= <<
 @members {
 this.Property = function() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/javascript/firefox/Firefox.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/javascript/firefox/Firefox.test.stg
@@ -237,6 +237,10 @@ LL_EXACT_AMBIG_DETECTION() ::= <<this._interp.predictionMode = antlr4.atn.Predic
 
 ParserToken(parser, token) ::= <%<parser>.<token>%>
 
+Production(p) ::= <%<p>%>
+
+Result(r) ::= <%<r>%>
+
 ParserPropertyMember() ::= <<
 @members {
 this.Property = function() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/javascript/node/Node.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/javascript/node/Node.test.stg
@@ -235,6 +235,10 @@ LL_EXACT_AMBIG_DETECTION() ::= <<this._interp.predictionMode = antlr4.atn.Predic
 
 ParserToken(parser, token) ::= <%<parser>.<token>%>
 
+Production(p) ::= <%<p>%>
+
+Result(r) ::= <%<r>%>
+
 ParserPropertyMember() ::= <<
 @members {
 this.Property = function() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/javascript/safari/Safari.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/javascript/safari/Safari.test.stg
@@ -235,6 +235,10 @@ LL_EXACT_AMBIG_DETECTION() ::= <<this._interp.predictionMode = antlr4.atn.Predic
 
 ParserToken(parser, token) ::= <%<parser>.<token>%>
 
+Production(p) ::= <%<p>%>
+
+Result(r) ::= <%<r>%>
+
 ParserPropertyMember() ::= <<
 @members {
 this.Property = function() {

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/python2/Python2.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/python2/Python2.test.stg
@@ -239,6 +239,10 @@ LL_EXACT_AMBIG_DETECTION() ::= <<self._interp.predictionMode =  PredictionMode.L
 
 ParserToken(parser, token) ::= <%<parser>.<token>%>
 
+Production(p) ::= <%<p>%>
+
+Result(r) ::= <%<r>%>
+
 ParserPropertyMember() ::= <<
 @members {
 def Property(self):

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/python3/Python3.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/python3/Python3.test.stg
@@ -241,6 +241,10 @@ LL_EXACT_AMBIG_DETECTION() ::= <<self._interp.predictionMode =  PredictionMode.L
 
 ParserToken(parser, token) ::= <%<parser>.<token>%>
 
+Production(p) ::= <%<p>%>
+
+Result(r) ::= <%<r>%>
+
 ParserPropertyMember() ::= <<
 @members {
 def Property(self):

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/LeftRecursion/MultipleAlternativesWithCommonLabel.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/LeftRecursion/MultipleAlternativesWithCommonLabel.stg
@@ -21,8 +21,8 @@ grammar(grammarName) ::= <<
 grammar <grammarName>;
 s : e {<writeln("$e.v")>};
 e returns [int v]
-  : e '*' e     {$v = <Cast("BinaryContext","$ctx")>.e(0).v * <Cast("BinaryContext","$ctx")>.e(1).v;}  # binary
-  | e '+' e     {$v = <Cast("BinaryContext","$ctx")>.e(0).v + <Cast("BinaryContext","$ctx")>.e(1).v;}  # binary
+  : e '*' e     {$v = <Cast("BinaryContext","$ctx")>.<Production("e")>(0).<Result("v")> * <Cast("BinaryContext","$ctx")>.<Production("e")>(1).<Result("v")>;}  # binary
+  | e '+' e     {$v = <Cast("BinaryContext","$ctx")>.<Production("e")>(0).<Result("v")> + <Cast("BinaryContext","$ctx")>.<Production("e")>(1).<Result("v")>;}  # binary
   | INT         {$v = $INT.int;}                   # anInt
   | '(' e ')'   {$v = $e.v;}                       # parens
   | left=e INC  {<Cast("UnaryContext","$ctx"):Concat(".INC() != null"):Assert()>$v = $left.v + 1;}      # unary

--- a/runtime-testsuite/src/org/antlr/v4/testgen/TestGenerator.java
+++ b/runtime-testsuite/src/org/antlr/v4/testgen/TestGenerator.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.STGroupFile;
+import org.stringtemplate.v4.StringRenderer;
 import org.stringtemplate.v4.gui.STViz;
 
 public class TestGenerator {
@@ -169,6 +170,7 @@ public class TestGenerator {
 	public void execute() {
 		STGroup targetGroup = new STGroupFile(runtimeTemplate.getPath());
 		targetGroup.registerModelAdaptor(STGroup.class, new STGroupModelAdaptor());
+		targetGroup.registerRenderer(String.class, new StringRenderer(), true);
 		targetGroup.defineDictionary("escape", new JavaEscapeStringMap());
 		targetGroup.defineDictionary("lines", new LinesStringMap());
 		targetGroup.defineDictionary("strlen", new StrlenStringMap());

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestLeftRecursion.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestLeftRecursion.java
@@ -1723,12 +1723,12 @@ public class TestLeftRecursion extends BaseTest {
 	@Test
 	public void testMultipleAlternativesWithCommonLabel_1() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(576);
+		StringBuilder grammarBuilder = new StringBuilder(596);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s : e {fmt.Println($e.v)};\n");
 		grammarBuilder.append("e returns [int v]\n");
-		grammarBuilder.append("  : e '*' e     {$v = ($ctx).e(0).v * ($ctx).e(1).v;}  # binary\n");
-		grammarBuilder.append("  | e '+' e     {$v = ($ctx).e(0).v + ($ctx).e(1).v;}  # binary\n");
+		grammarBuilder.append("  : e '*' e     {$v = ($ctx).E(0).GetV() * ($ctx).E(1).GetV();}  # binary\n");
+		grammarBuilder.append("  | e '+' e     {$v = ($ctx).E(0).GetV() + ($ctx).E(1).GetV();}  # binary\n");
 		grammarBuilder.append("  | INT         {$v = $INT.int;}                   # anInt\n");
 		grammarBuilder.append("  | '(' e ')'   {$v = $e.v;}                       # parens\n");
 		grammarBuilder.append("  | left=e INC  {$v = $left.v + 1;}      # unary\n");
@@ -1752,12 +1752,12 @@ public class TestLeftRecursion extends BaseTest {
 	@Test
 	public void testMultipleAlternativesWithCommonLabel_2() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(576);
+		StringBuilder grammarBuilder = new StringBuilder(596);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s : e {fmt.Println($e.v)};\n");
 		grammarBuilder.append("e returns [int v]\n");
-		grammarBuilder.append("  : e '*' e     {$v = ($ctx).e(0).v * ($ctx).e(1).v;}  # binary\n");
-		grammarBuilder.append("  | e '+' e     {$v = ($ctx).e(0).v + ($ctx).e(1).v;}  # binary\n");
+		grammarBuilder.append("  : e '*' e     {$v = ($ctx).E(0).GetV() * ($ctx).E(1).GetV();}  # binary\n");
+		grammarBuilder.append("  | e '+' e     {$v = ($ctx).E(0).GetV() + ($ctx).E(1).GetV();}  # binary\n");
 		grammarBuilder.append("  | INT         {$v = $INT.int;}                   # anInt\n");
 		grammarBuilder.append("  | '(' e ')'   {$v = $e.v;}                       # parens\n");
 		grammarBuilder.append("  | left=e INC  {$v = $left.v + 1;}      # unary\n");
@@ -1781,12 +1781,12 @@ public class TestLeftRecursion extends BaseTest {
 	@Test
 	public void testMultipleAlternativesWithCommonLabel_3() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(576);
+		StringBuilder grammarBuilder = new StringBuilder(596);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s : e {fmt.Println($e.v)};\n");
 		grammarBuilder.append("e returns [int v]\n");
-		grammarBuilder.append("  : e '*' e     {$v = ($ctx).e(0).v * ($ctx).e(1).v;}  # binary\n");
-		grammarBuilder.append("  | e '+' e     {$v = ($ctx).e(0).v + ($ctx).e(1).v;}  # binary\n");
+		grammarBuilder.append("  : e '*' e     {$v = ($ctx).E(0).GetV() * ($ctx).E(1).GetV();}  # binary\n");
+		grammarBuilder.append("  | e '+' e     {$v = ($ctx).E(0).GetV() + ($ctx).E(1).GetV();}  # binary\n");
 		grammarBuilder.append("  | INT         {$v = $INT.int;}                   # anInt\n");
 		grammarBuilder.append("  | '(' e ')'   {$v = $e.v;}                       # parens\n");
 		grammarBuilder.append("  | left=e INC  {$v = $left.v + 1;}      # unary\n");
@@ -1810,12 +1810,12 @@ public class TestLeftRecursion extends BaseTest {
 	@Test
 	public void testMultipleAlternativesWithCommonLabel_4() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(576);
+		StringBuilder grammarBuilder = new StringBuilder(596);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s : e {fmt.Println($e.v)};\n");
 		grammarBuilder.append("e returns [int v]\n");
-		grammarBuilder.append("  : e '*' e     {$v = ($ctx).e(0).v * ($ctx).e(1).v;}  # binary\n");
-		grammarBuilder.append("  | e '+' e     {$v = ($ctx).e(0).v + ($ctx).e(1).v;}  # binary\n");
+		grammarBuilder.append("  : e '*' e     {$v = ($ctx).E(0).GetV() * ($ctx).E(1).GetV();}  # binary\n");
+		grammarBuilder.append("  | e '+' e     {$v = ($ctx).E(0).GetV() + ($ctx).E(1).GetV();}  # binary\n");
 		grammarBuilder.append("  | INT         {$v = $INT.int;}                   # anInt\n");
 		grammarBuilder.append("  | '(' e ')'   {$v = $e.v;}                       # parens\n");
 		grammarBuilder.append("  | left=e INC  {$v = $left.v + 1;}      # unary\n");

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
@@ -62,7 +62,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testLR() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(723);
+		StringBuilder grammarBuilder = new StringBuilder(718);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -78,7 +78,7 @@ public class TestListeners extends BaseTest {
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitE(ctx *EContext) {\n");
 		grammarBuilder.append("	if ctx.GetChildCount() == 3 {\n");
-		grammarBuilder.append("		fmt.Printf(\"%s %s %s\\n\", ctx.E(0)[0].GetStart().GetText(), ctx.E(1)[0].GetStart().GetText(), ctx.E(-1)[0].GetStart().GetText())\n");
+		grammarBuilder.append("		fmt.Printf(\"%s %s %s\\n\", ctx.E(0).GetStart().GetText(), ctx.E(1).GetStart().GetText(), ctx.AllE()[0].GetStart().GetText())\n");
 		grammarBuilder.append("	} else {\n");
 		grammarBuilder.append("		fmt.Println(ctx.INT().GetSymbol().GetText())\n");
 		grammarBuilder.append("	}\n");
@@ -177,7 +177,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testRuleGetters_1() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(749);
+		StringBuilder grammarBuilder = new StringBuilder(741);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -193,9 +193,9 @@ public class TestListeners extends BaseTest {
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitA(ctx *AContext) {\n");
 		grammarBuilder.append("	if ctx.GetChildCount() == 2 {\n");
-		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.B(0)[0].GetStart().GetText(), ctx.B(1)[0].GetStart().GetText(), ctx.B(-1)[0].GetStart().GetText())\n");
+		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.B(0).GetStart().GetText(), ctx.B(1).GetStart().GetText(), ctx.AllB()[0].GetStart().GetText())\n");
 		grammarBuilder.append("	} else {\n");
-		grammarBuilder.append("		fmt.Println(ctx.B(0)[0].GetStart().GetText())\n");
+		grammarBuilder.append("		fmt.Println(ctx.B(0).GetStart().GetText())\n");
 		grammarBuilder.append("	}\n");
 		grammarBuilder.append("}\n");
 		grammarBuilder.append("}\n");
@@ -231,7 +231,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testRuleGetters_2() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(749);
+		StringBuilder grammarBuilder = new StringBuilder(741);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -247,9 +247,9 @@ public class TestListeners extends BaseTest {
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitA(ctx *AContext) {\n");
 		grammarBuilder.append("	if ctx.GetChildCount() == 2 {\n");
-		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.B(0)[0].GetStart().GetText(), ctx.B(1)[0].GetStart().GetText(), ctx.B(-1)[0].GetStart().GetText())\n");
+		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.B(0).GetStart().GetText(), ctx.B(1).GetStart().GetText(), ctx.AllB()[0].GetStart().GetText())\n");
 		grammarBuilder.append("	} else {\n");
-		grammarBuilder.append("		fmt.Println(ctx.B(0)[0].GetStart().GetText())\n");
+		grammarBuilder.append("		fmt.Println(ctx.B(0).GetStart().GetText())\n");
 		grammarBuilder.append("	}\n");
 		grammarBuilder.append("}\n");
 		grammarBuilder.append("}\n");
@@ -285,7 +285,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testTokenGetters_1() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(681);
+		StringBuilder grammarBuilder = new StringBuilder(674);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -301,7 +301,7 @@ public class TestListeners extends BaseTest {
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitA(ctx *AContext) {\n");
 		grammarBuilder.append("	if ctx.GetChildCount() == 2 {\n");
-		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0)[0].GetSymbol().GetText(), ctx.INT(1)[0].GetSymbol().GetText(), ctx.INT(0)[0])\n");
+		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), ctx.AllINT())\n");
 		grammarBuilder.append("	} else {\n");
 		grammarBuilder.append("		fmt.Println(ctx.ID().GetSymbol())\n");
 		grammarBuilder.append("	}\n");
@@ -338,7 +338,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testTokenGetters_2() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(681);
+		StringBuilder grammarBuilder = new StringBuilder(674);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -354,7 +354,7 @@ public class TestListeners extends BaseTest {
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitA(ctx *AContext) {\n");
 		grammarBuilder.append("	if ctx.GetChildCount() == 2 {\n");
-		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0)[0].GetSymbol().GetText(), ctx.INT(1)[0].GetSymbol().GetText(), ctx.INT(0)[0])\n");
+		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), ctx.AllINT())\n");
 		grammarBuilder.append("	} else {\n");
 		grammarBuilder.append("		fmt.Println(ctx.ID().GetSymbol())\n");
 		grammarBuilder.append("	}\n");

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParserExec.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParserExec.java
@@ -599,10 +599,10 @@ public class TestParserExec extends BaseTest {
 	@Test
 	public void testPredictionIssue334() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(251);
+		StringBuilder grammarBuilder = new StringBuilder(255);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("file_ @init{\n");
-		grammarBuilder.append("p.SetErrorHandler(p.NewBailErrorStrategy())\n");
+		grammarBuilder.append("p.SetErrorHandler(antlr.NewBailErrorStrategy())\n");
 		grammarBuilder.append("} \n");
 		grammarBuilder.append("@after {\n");
 		grammarBuilder.append("fmt.Println($ctx.ToStringTree(nil, p))\n");

--- a/runtime/Go/antlr/error_strategy.go
+++ b/runtime/Go/antlr/error_strategy.go
@@ -26,6 +26,8 @@ type DefaultErrorStrategy struct {
 	lastErrorStates   *IntervalSet
 }
 
+var _ ErrorStrategy = &DefaultErrorStrategy{}
+
 func NewDefaultErrorStrategy() *DefaultErrorStrategy {
 
 	d := new(DefaultErrorStrategy)
@@ -737,6 +739,8 @@ type BailErrorStrategy struct {
 	*DefaultErrorStrategy
 }
 
+var _ ErrorStrategy = &BailErrorStrategy{}
+
 func NewBailErrorStrategy() *BailErrorStrategy {
 
 	b := new(BailErrorStrategy)
@@ -763,8 +767,10 @@ func (b *BailErrorStrategy) Recover(recognizer Parser, e RecognitionException) {
 // Make sure we don't attempt to recover inline if the parser
 // successfully recovers, it won't panic an exception.
 //
-func (b *BailErrorStrategy) RecoverInline(recognizer Parser) {
+func (b *BailErrorStrategy) RecoverInline(recognizer Parser) Token {
 	b.Recover(recognizer, NewInputMisMatchException(recognizer))
+
+	return nil
 }
 
 // Make sure we don't attempt to recover from problems in subrules.//

--- a/runtime/Go/antlr/rule_context.go
+++ b/runtime/Go/antlr/rule_context.go
@@ -63,7 +63,11 @@ func (b *BaseRuleContext) GetBaseRuleContext() *BaseRuleContext {
 }
 
 func (b *BaseRuleContext) SetParent(v Tree) {
-	b.parentCtx = v.(RuleContext)
+	if v == nil {
+		b.parentCtx = nil
+	} else {
+		b.parentCtx = v.(RuleContext)
+	}
 }
 
 func (b *BaseRuleContext) GetInvokingState() int {

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -347,7 +347,7 @@ func (l *<lexer.name>) <r.name; format="cap">_Action(localctx <if(r.isRuleContex
  * overriding implementation impossible to maintain.
  */
 RuleSempredFunction(r, actions) ::= <<
-func (p *<if(parser)><parser.name><else><lexer.name><endif>) <r.name; format="cap">_Sempred(localctx antlr.RuleContext, predIndex int) bool {
+func (p *<r.recognizerName>) <r.name; format="cap">_Sempred(localctx antlr.RuleContext, predIndex int) bool {
 	switch predIndex {
 	<if(actions)>
 	<actions:{index | case <index>:
@@ -371,7 +371,7 @@ RuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs, namedAction
 
 
 <endif>
-func (p *<parser.name>) <currentRule.name; format="cap">(<currentRule.args:{a | <a.name> <a.type>}; separator=", ">) (localctx I<currentRule.ctxType>) {
+func (p *<currentRule.recognizerName>) <currentRule.name; format="cap">(<currentRule.args:{a | <a.name> <a.type>}; separator=", ">) (localctx I<currentRule.ctxType>) {
 	localctx = New<currentRule.ctxType>(p, p.GetParserRuleContext(), p.GetState()<currentRule.args:{a | , <a.name>}>)
 	p.EnterRule(localctx, <currentRule.startState>, <parser.name>RULE_<currentRule.name>)
 	<if(namedActions.init)>
@@ -429,13 +429,18 @@ LeftRecursiveRuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs
 <ruleCtx>
 
 
+
 <endif>
 <if(altLabelCtxs)>
 <altLabelCtxs:{l | <altLabelCtxs.(l)>}; separator="\n\n">
 
 
 <endif>
-func (p *<parser.name>) <currentRule.name; format="cap">(_p int<if(currentRule.args)>, <args:{a | , <a.name> <a.type>}><endif>) (localctx I<currentRule.ctxType>) {
+func (p *<currentRule.recognizerName>) <currentRule.name; format="cap">(<args:{a | <a.name> <a.type>}; separator=", ">) (localctx I<currentRule.ctxType>) {
+	return p.<currentRule.name>(0<args:{a | , <a.name>}>)
+}
+
+func (p *<currentRule.recognizerName>) <currentRule.name>(_p int<args:{a | , <a.name> <a.type>}>) (localctx I<currentRule.ctxType>) {
 	var _parentctx antlr.ParserRuleContext = p.GetParserRuleContext()
 	_parentState := p.GetState()
 	localctx = New<currentRule.ctxType>(p, p.GetParserRuleContext(), _parentState<args:{a | , <a.name>}>)
@@ -731,11 +736,20 @@ InvokeRule(r, argExprsChunks) ::= <<
 p.SetState(<r.stateNumber>)
 <if(r.labels)>
 
-var _x = p.<r.name; format="cap">(<if(r.ast.options.p)><r.ast.options.p><if(argExprsChunks)>,<endif><endif><argExprsChunks>)
+<if(r.ast.options.p)>
+var _x = p.<r.name>(<r.ast.options.p><if(argExprsChunks)>, <endif><argExprsChunks>)
+<else>
+var _x = p.<r.name; format="cap">(<argExprsChunks>)
+<endif>
+
 
 <r.labels:{l | <labelref(l)> = _x}; separator="\n">
 <else>
-p.<r.name; format="cap">(<if(r.ast.options.p)><r.ast.options.p><if(argExprsChunks)>,<endif><endif><argExprsChunks>)
+<if(r.ast.options.p)>
+p.<r.name>(<r.ast.options.p><if(argExprsChunks)>, <endif><argExprsChunks>)
+<else>
+p.<r.name; format="cap">(<argExprsChunks>)
+<endif>
 <endif>
 >>
 
@@ -881,58 +895,54 @@ ContextTokenGetterDecl(t) ::= <<
 }
 >>
 
-// should never be called
 ContextTokenListGetterDecl(t) ::= <<
-fail: ContextTokenListGetterDecl should never be called!
+All<t.name; format="cap">() []antlr.TerminalNode {
+	return s.GetTokens(<parser.name><t.name>)
+}
 >>
 
 ContextTokenListIndexedGetterDecl(t) ::= <<
-<t.name; format="cap">(i int) []antlr.TerminalNode {
-	if i \< 0 {
-		return s.GetTokens(<parser.name><t.name>)
-	} else {
-		return []antlr.TerminalNode{s.GetToken(<parser.name><t.name>, i)}
-	}
+<t.name; format="cap">(i int) antlr.TerminalNode {
+	return s.GetToken(<parser.name><t.name>, i)
 }
 >>
 
 ContextRuleGetterDecl(r) ::= <<
 <r.name; format="cap">() I<r.ctxName> {
-	v := s.GetTypedRuleContext(reflect.TypeOf((*I<r.ctxName>)(nil)).Elem(), 0)
+	var t = s.GetTypedRuleContext(reflect.TypeOf((*I<r.ctxName>)(nil)).Elem(), 0)
 
-	if v == nil {
+	if t == nil {
 		return nil
 	}
 
-	return v.(I<r.ctxName>)
+	return t.(I<r.ctxName>)
 }
 >>
 
-// should never be called
 ContextRuleListGetterDecl(r) ::= <<
-fail: ContextRuleListGetterDecl should never be called!
->>
+All<r.name; format="cap">() []I<r.ctxName> {
+	var ts = s.GetTypedRuleContexts(reflect.TypeOf((*I<r.ctxName>)(nil)).Elem())
+	var tst = make([]I<r.ctxName>, len(ts))
 
-ContextRuleListIndexedGetterDecl(r) ::= <<
-<r.name; format="cap">(i int) []I<r.ctxName> {
-	var ts []antlr.RuleContext
-
-	if i \< 0 {
-		ts = s.GetTypedRuleContexts(reflect.TypeOf((*I<r.ctxName>)(nil)).Elem())
-	} else {
-		ts = []antlr.RuleContext{s.GetTypedRuleContext(reflect.TypeOf((*I<r.ctxName>)(nil)).Elem(), i)}
-	}
-
-	var tst []I<r.ctxName> = make([]I<r.ctxName>, len(ts))
 	for i, t := range ts {
-		if t == nil {
-			tst[i] = nil
-		} else {
+		if t != nil {
 			tst[i] = t.(I<r.ctxName>)
 		}
 	}
 
 	return tst
+}
+>>
+
+ContextRuleListIndexedGetterDecl(r) ::= <<
+<r.name; format="cap">(i int) I<r.ctxName> {
+	var t = s.GetTypedRuleContext(reflect.TypeOf((*I<r.ctxName>)(nil)).Elem(), i)
+
+	if t == nil {
+		return nil
+	}
+
+	return t.(I<r.ctxName>)
 }
 >>
 

--- a/tool/src/org/antlr/v4/codegen/model/LeftRecursiveRuleFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/LeftRecursiveRuleFunction.java
@@ -42,6 +42,8 @@ import org.antlr.v4.tool.Rule;
 import org.antlr.v4.tool.ast.GrammarAST;
 
 public class LeftRecursiveRuleFunction extends RuleFunction {
+	public String recognizerName;
+
 	public LeftRecursiveRuleFunction(OutputModelFactory factory, LeftRecursiveRule r) {
 		super(factory, r);
 
@@ -72,5 +74,7 @@ public class LeftRecursiveRuleFunction extends RuleFunction {
 				struct.addDecl(d); // stick in overall rule's ctx
 			}
 		}
+
+		recognizerName = factory.getGrammar().getRecognizerName();
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/RuleFunction.java
@@ -81,6 +81,7 @@ public class RuleFunction extends OutputModelObject {
 	public Rule rule;
 	public AltLabelStructDecl[] altToContext;
 	public boolean hasLookaheadBlock;
+	public String recognizerName;
 
 	@ModelElement public List<SrcOp> code;
 	@ModelElement public OrderedHashSet<Decl> locals; // TODO: move into ctx?
@@ -138,6 +139,7 @@ public class RuleFunction extends OutputModelObject {
 		}
 
 		startState = factory.getGrammar().atn.ruleToStartState[r.index];
+		recognizerName = factory.getGrammar().getRecognizerName();
 	}
 
 	public void addContextGetters(OutputModelFactory factory, Rule r) {

--- a/tool/src/org/antlr/v4/codegen/model/RuleSempredFunction.java
+++ b/tool/src/org/antlr/v4/codegen/model/RuleSempredFunction.java
@@ -34,7 +34,10 @@ import org.antlr.v4.codegen.OutputModelFactory;
 import org.antlr.v4.tool.Rule;
 
 public class RuleSempredFunction extends RuleActionFunction {
+	public String recognizerName;
+
 	public RuleSempredFunction(OutputModelFactory factory, Rule r, String ctxType) {
 		super(factory, r, ctxType);
+		recognizerName = factory.getGrammar().getRecognizerName();
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/target/GoTarget.java
+++ b/tool/src/org/antlr/v4/codegen/target/GoTarget.java
@@ -147,17 +147,5 @@ public class GoTarget extends Target {
 		}
 
 	}
-
-	public boolean wantsBaseListener() {
-		return true;
-	}
-
-	public boolean wantsBaseVisitor() {
-		return true;
-	}
-
-	public boolean supportsOverloadedMethods() {
-		return false;
-	}
 }
 


### PR DESCRIPTION
Some tests were failing because the test template had `e` hard-coded as the production name, but exported Go names are uppercase.

I added a `Production` template that capitalizes the param for Go and just returns the param for the other languages.

Edit: Wrong word
