### PR TITLE
Fix LRWithLabelsListener to call EList.String

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/go/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/go/Go.test.stg
@@ -409,7 +409,7 @@ func NewLeafListener() *LeafListener {
 }
 
 func (*LeafListener) ExitCall(ctx *CallContext) {
-	fmt.Printf("%s %s", ctx.E().GetStart().GetText(), ctx.EList())
+	fmt.Printf("%s %s", ctx.E().GetStart().GetText(), ctx.EList().String(nil, nil))
 }
 
 func (*LeafListener) ExitInt(ctx *IntContext) {

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
@@ -120,7 +120,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testLRWithLabels() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(709);
+		StringBuilder grammarBuilder = new StringBuilder(726);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -135,7 +135,7 @@ public class TestListeners extends BaseTest {
 		grammarBuilder.append("}\n");
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitCall(ctx *CallContext) {\n");
-		grammarBuilder.append("	fmt.Printf(\"%s %s\", ctx.E().GetStart().GetText(), ctx.EList())\n");
+		grammarBuilder.append("	fmt.Printf(\"%s %s\", ctx.E().GetStart().GetText(), ctx.EList().String(nil, nil))\n");
 		grammarBuilder.append("}\n");
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitInt(ctx *IntContext) {\n");


### PR DESCRIPTION
Fixes test TestListeners.testLRWithLabels failure.
