### PR TITLE
Remaining work

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 # ANTLR4 Language Target, Runtime for Go
 
-[![Join the chat at https://gitter.im/pboyer/antlr4](https://badges.gitter.im/pboyer/antlr4.svg)](https://gitter.im/pboyer/antlr4?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/pboyer/antlr4.svg?branch=master)](https://travis-ci.org/pboyer/antlr4)
+[![Join the chat at https://gitter.im/willfaught/antlr4](https://badges.gitter.im/willfaught/antlr4.svg)](https://gitter.im/willfaught/antlr4?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/willfaught/antlr4.svg?branch=master)](https://travis-ci.org/willfaught/antlr4)
 
 ### Usage
 
-1. `go get http://github.com/pboyer/antlr4`
+1. `go get http://github.com/willfaught/antlr4`
 2. Get [StringTemplate](http://www.stringtemplate.org/)
 3. Get [Maven](https://maven.apache.org/download.cgi)
   - Put `mvn` in your PATH (e.g. in `~/.bashrc` add `export PATH=$PATH:/path/to/apache-maven-3.3.9/bin`)
 4. From the repo directory, `mvn install` (add `-DskipTests` to skip the tests)
 5. Put StringTemplate and ANTLR binaries on your `CLASSPATH`
   - `export CLASSPATH=".:/path/to/ST-4.0.8.jar:$CLASSPATH"`
-  - `export CLASSPATH=".:$GOPATH/src/github.com/pboyer/antlr4/tool/target/antlr4-4.5.2-SNAPSHOT.jar:$CLASSPATH"`
+  - `export CLASSPATH=".:$GOPATH/src/github.com/willfaught/antlr4/tool/target/antlr4-4.5.2-SNAPSHOT.jar:$CLASSPATH"`
 5. (Optional) Add an alias for calling antlr
-  - `alias antlr='java -jar $GOPATH/src/github.com/pboyer/antlr4/tool/target/antlr4-4.5.2-SNAPSHOT.jar'`
+  - `alias antlr='java -jar $GOPATH/src/github.com/willfaught/antlr4/tool/target/antlr4-4.5.2-SNAPSHOT.jar'`
 6. Now, `antlr Grammar.g4 -Dlanguage=Go`
 
 ---

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/BaseTest.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/BaseTest.java
@@ -110,7 +110,7 @@ public abstract class BaseTest {
 	public File tmpdir = null;
 	public File parserpkgdir = null; // this is where the parser package is stored, typically inside the tmpdir
 	private static File tmpGopath = null;
-	private static final String GO_RUNTIME_IMPORT_PATH = "github.com/pboyer/antlr4/runtime/Go/antlr"; // TODO: Change this before merging with upstream
+	private static final String GO_RUNTIME_IMPORT_PATH = "github.com/willfaught/antlr4/runtime/Go/antlr"; // TODO: Change this before merging with upstream
 
 	/**
 	 * If error during parser execution, store stderr here; can't return stdout
@@ -834,7 +834,7 @@ public abstract class BaseTest {
 			ST outputFileST = new ST(
 					"package main\n" +
 						"import (\n"
-						+"	\"github.com/pboyer/antlr4/runtime/Go/antlr\"\n"
+						+"	\"github.com/willfaught/antlr4/runtime/Go/antlr\"\n"
 						+"	\"./parser\"\n"
 						+"	\"os\"\n"
 						+")\n"
@@ -889,7 +889,7 @@ public abstract class BaseTest {
 		ST outputFileST = new ST(
 				"package main\n" +
 				"import (\n"
-					+ "	\"github.com/pboyer/antlr4/runtime/Go/antlr\"\n"
+					+ "	\"github.com/willfaught/antlr4/runtime/Go/antlr\"\n"
 					+ "	\"./parser\"\n"
 					+ "	\"os\"\n"
 					+ "	\"fmt\"\n"

--- a/runtime/Go/antlr/tree.go
+++ b/runtime/Go/antlr/tree.go
@@ -56,6 +56,8 @@ type ParseTreeVisitor interface {
 
 type BaseParseTreeVisitor struct{}
 
+var _ ParseTreeVisitor = &BaseParseTreeVisitor{}
+
 func (v *BaseParseTreeVisitor) Visit(tree ParseTree) interface{}            { return nil }
 func (v *BaseParseTreeVisitor) VisitChildren(node RuleNode) interface{}     { return nil }
 func (v *BaseParseTreeVisitor) VisitTerminal(node TerminalNode) interface{} { return nil }
@@ -91,6 +93,8 @@ type ParseTreeListener interface {
 
 type BaseParseTreeListener struct{}
 
+var _ ParseTreeListener = &BaseParseTreeListener{}
+
 func (l *BaseParseTreeListener) VisitTerminal(node TerminalNode)      {}
 func (l *BaseParseTreeListener) VisitErrorNode(node ErrorNode)        {}
 func (l *BaseParseTreeListener) EnterEveryRule(ctx ParserRuleContext) {}
@@ -101,6 +105,8 @@ type TerminalNodeImpl struct {
 
 	symbol Token
 }
+
+var _ TerminalNode = &TerminalNodeImpl{}
 
 func NewTerminalNodeImpl(symbol Token) *TerminalNodeImpl {
 	tn := new(TerminalNodeImpl)
@@ -180,6 +186,8 @@ func (t *TerminalNodeImpl) ToStringTree(s []string, r Recognizer) string {
 type ErrorNodeImpl struct {
 	*TerminalNodeImpl
 }
+
+var _ ErrorNode = &ErrorNodeImpl{}
 
 func NewErrorNodeImpl(token Token) *ErrorNodeImpl {
 	en := new(ErrorNodeImpl)

--- a/runtime/JavaScript/src/antlr4/index.js
+++ b/runtime/JavaScript/src/antlr4/index.js
@@ -1,4 +1,4 @@
-PORT_DEBUG = false; // TODO(pboyer) remove
+PORT_DEBUG = false; // TODO(willfaught) remove
 
 exports.atn = require('./atn/index');
 exports.dfa = require('./dfa/index');

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -75,6 +75,8 @@ import "github.com/pboyer/antlr4/runtime/Go/antlr"
 // Base<file.grammarName>Listener is a complete listener for a parse tree produced by <file.parserName>.
 type Base<file.grammarName>Listener struct{}
 
+var _ <file.grammarName>Listener = &Base<file.grammarName>Listener{}
+
 // VisitTerminal is called when a terminal node is visited.
 func (s *Base<file.grammarName>Listener) VisitTerminal(node antlr.TerminalNode) {}
 

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Go/Go.stg
@@ -16,7 +16,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/pboyer/antlr4/runtime/Go/antlr"
+	"github.com/willfaught/antlr4/runtime/Go/antlr"
 )
 
 // Stopgap to suppress unused import error. We aren't certain
@@ -46,7 +46,7 @@ package <file.genPackage> // <file.grammarName>
 package parser // <file.grammarName>
 <endif>
 
-import "github.com/pboyer/antlr4/runtime/Go/antlr"
+import "github.com/willfaught/antlr4/runtime/Go/antlr"
 
 // <file.grammarName>Listener is a complete listener for a parse tree produced by <file.parserName>.
 type <file.grammarName>Listener interface {
@@ -70,7 +70,7 @@ package <file.genPackage> // <file.grammarName>
 package parser // <file.grammarName>
 <endif>
 
-import "github.com/pboyer/antlr4/runtime/Go/antlr"
+import "github.com/willfaught/antlr4/runtime/Go/antlr"
 
 // Base<file.grammarName>Listener is a complete listener for a parse tree produced by <file.parserName>.
 type Base<file.grammarName>Listener struct{}
@@ -106,7 +106,7 @@ package <file.genPackage> // <file.grammarName>
 package parser // <file.grammarName>
 <endif>
 
-import "github.com/pboyer/antlr4/runtime/Go/antlr"
+import "github.com/willfaught/antlr4/runtime/Go/antlr"
 <if(header)>
 
 <header>
@@ -132,7 +132,7 @@ package <file.genPackage> // <file.grammarName>
 package parser // <file.grammarName>
 <endif>
 
-import "github.com/pboyer/antlr4/runtime/Go/antlr"
+import "github.com/willfaught/antlr4/runtime/Go/antlr"
 
 type Base<file.grammarName>Visitor struct {
 	*antlr.BaseParseTreeVisitor
@@ -1332,7 +1332,7 @@ package parser
 import (
 	"fmt"
 
-	"github.com/pboyer/antlr4/runtime/Go/antlr"
+	"github.com/willfaught/antlr4/runtime/Go/antlr"
 )
 
 // suppress unused import error, many tests


### PR DESCRIPTION
@pboyer @wjkohnen

_(Ignore the diff for now, it's just a placeholder.)_

Guys, we're almost there! Let's finish this thing!
# CLA

We all still need to sign the CLA (contributors.txt). Let's do it now so the upstream PR isn't blocked on the whole group when it's ready.
# Testing

We're down to 9 failures and 1 error. We're so close! :)

I've been rooting out several errors in the tests themselves, which mainly are caused by Go being different than the other target languages in various ways. This is all low-hanging fruit.

Some tests fail because there's no output at all, either `<[]>` or just `null`. No idea yet what's going on there, but it seems like it should be easy to debug.

Some tests fail because they expect something like:

```
<(1 2)
[1
2]>
```

but get:

```
<(1 2)
[]>
```

which is a little more intuitive to debug (e.g. something isn't printing for each integer, possibly a rule action).

There's one that sets LLAmbigSomethingSomething and I have no idea why that's not working.

@pboyer, your knowledge of why some parts of the runtime don't match the other implementations (like tree/trees.go, it seems?) is invaluable here. I could compare the Go runtime to the Java one line-by-line, but it's too tedious. There are some runtime TODOs that still need to be addressed, which seems easy, and it isn't clear whether these are related to the test failures.

I haven't done an entire test run for all languages in a while, so I actually don't know whether the test fixes I've made have affected the other languages, although any problems there should be easy to fix. And _I think_ Travis is testing all languages anyway?
# Polish

I haven't done a full polish pass through the runtime or generated code, as that seems lower priority than getting tests passing and acceptable for upstream PR, so I'm waiting on this until everything passes.

Aside from general code style consistency, there's also some design changes that need to happen to be idiomatic, like renaming GetFoo() funcs to Foo(), hiding implementations of interfaces that don't need to be exposed, etc.

I'm also not sure whether BaseFoo is idiomatic; I could see how it might be DefaultFoo or something, but I haven't looked into it yet to verify.

It might also make sense to make token types something other than int so they're distinct values and not easily used incorrectly with other ints.

It would be good to add more interface implementation assertions via blank var decls.
