### PR TITLE
Print test arrays in java style

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/go/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/go/Go.test.stg
@@ -360,7 +360,7 @@ func NewLeafListener() *LeafListener {
 
 func (*LeafListener) ExitA(ctx *AContext) {
 	if ctx.GetChildCount() == 2 {
-		fmt.Printf("%s %s %s", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), ctx.AllINT())
+		fmt.Printf("%s %s %s", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintJavaStringArray(ctx.AllINT()))
 	} else {
 		fmt.Println(ctx.ID().GetSymbol())
 	}

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/go/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/go/Go.test.stg
@@ -220,7 +220,7 @@ ImportListener(X) ::= ""
 
 GetExpectedTokenNames() ::= "p.GetExpectedTokens().StringVerbose(p.GetTokenNames(), nil, false)"
 
-RuleInvocationStack() ::= "p.GetRuleInvocationStack(nil)"
+RuleInvocationStack() ::= "antlr.PrintJavaStringArray(p.GetRuleInvocationStack(nil))"
 
 LL_EXACT_AMBIG_DETECTION() ::= <<p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);>>
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/go/Go.test.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/go/Go.test.stg
@@ -220,7 +220,7 @@ ImportListener(X) ::= ""
 
 GetExpectedTokenNames() ::= "p.GetExpectedTokens().StringVerbose(p.GetTokenNames(), nil, false)"
 
-RuleInvocationStack() ::= "antlr.PrintJavaStringArray(p.GetRuleInvocationStack(nil))"
+RuleInvocationStack() ::= "antlr.PrintArrayJavaStyle(p.GetRuleInvocationStack(nil))"
 
 LL_EXACT_AMBIG_DETECTION() ::= <<p.Interpreter.SetPredictionMode(antlr.PredictionModeLLExactAmbigDetection);>>
 
@@ -360,7 +360,7 @@ func NewLeafListener() *LeafListener {
 
 func (*LeafListener) ExitA(ctx *AContext) {
 	if ctx.GetChildCount() == 2 {
-		fmt.Printf("%s %s %s", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintJavaStringArray(ctx.AllINT()))
+		fmt.Printf("%s %s %s", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintArrayJavaStyle(antlr.TerminalNodeToStringArray(ctx.AllINT())))
 	} else {
 		fmt.Println(ctx.ID().GetSymbol())
 	}

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
@@ -301,7 +301,7 @@ public class TestListeners extends BaseTest {
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitA(ctx *AContext) {\n");
 		grammarBuilder.append("	if ctx.GetChildCount() == 2 {\n");
-		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintJavaStringArray(ctx.AllINT()))\n");
+		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintArrayJavaStyle(ctx.AllINT()))\n");
 		grammarBuilder.append("	} else {\n");
 		grammarBuilder.append("		fmt.Println(ctx.ID().GetSymbol())\n");
 		grammarBuilder.append("	}\n");
@@ -354,7 +354,7 @@ public class TestListeners extends BaseTest {
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitA(ctx *AContext) {\n");
 		grammarBuilder.append("	if ctx.GetChildCount() == 2 {\n");
-		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintJavaStringArray(ctx.AllINT()))\n");
+		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintArrayJavaStyle(ctx.AllINT()))\n");
 		grammarBuilder.append("	} else {\n");
 		grammarBuilder.append("		fmt.Println(ctx.ID().GetSymbol())\n");
 		grammarBuilder.append("	}\n");

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
@@ -285,7 +285,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testTokenGetters_1() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(674);
+		StringBuilder grammarBuilder = new StringBuilder(702);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -301,7 +301,7 @@ public class TestListeners extends BaseTest {
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitA(ctx *AContext) {\n");
 		grammarBuilder.append("	if ctx.GetChildCount() == 2 {\n");
-		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), ctx.AllINT())\n");
+		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintJavaStringArray(ctx.AllINT()))\n");
 		grammarBuilder.append("	} else {\n");
 		grammarBuilder.append("		fmt.Println(ctx.ID().GetSymbol())\n");
 		grammarBuilder.append("	}\n");
@@ -338,7 +338,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testTokenGetters_2() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(674);
+		StringBuilder grammarBuilder = new StringBuilder(702);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -354,7 +354,7 @@ public class TestListeners extends BaseTest {
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitA(ctx *AContext) {\n");
 		grammarBuilder.append("	if ctx.GetChildCount() == 2 {\n");
-		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), ctx.AllINT())\n");
+		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintJavaStringArray(ctx.AllINT()))\n");
 		grammarBuilder.append("	} else {\n");
 		grammarBuilder.append("		fmt.Println(ctx.ID().GetSymbol())\n");
 		grammarBuilder.append("	}\n");

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestListeners.java
@@ -285,7 +285,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testTokenGetters_1() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(702);
+		StringBuilder grammarBuilder = new StringBuilder(734);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -301,7 +301,7 @@ public class TestListeners extends BaseTest {
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitA(ctx *AContext) {\n");
 		grammarBuilder.append("	if ctx.GetChildCount() == 2 {\n");
-		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintArrayJavaStyle(ctx.AllINT()))\n");
+		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintArrayJavaStyle(antlr.TerminalNodeToStringArray(ctx.AllINT())))\n");
 		grammarBuilder.append("	} else {\n");
 		grammarBuilder.append("		fmt.Println(ctx.ID().GetSymbol())\n");
 		grammarBuilder.append("	}\n");
@@ -338,7 +338,7 @@ public class TestListeners extends BaseTest {
 	@Test
 	public void testTokenGetters_2() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(702);
+		StringBuilder grammarBuilder = new StringBuilder(734);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("@parser::header {\n");
 		grammarBuilder.append("}\n");
@@ -354,7 +354,7 @@ public class TestListeners extends BaseTest {
 		grammarBuilder.append("\n");
 		grammarBuilder.append("func (*LeafListener) ExitA(ctx *AContext) {\n");
 		grammarBuilder.append("	if ctx.GetChildCount() == 2 {\n");
-		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintArrayJavaStyle(ctx.AllINT()))\n");
+		grammarBuilder.append("		fmt.Printf(\"%s %s %s\", ctx.INT(0).GetSymbol().GetText(), ctx.INT(1).GetSymbol().GetText(), antlr.PrintArrayJavaStyle(antlr.TerminalNodeToStringArray(ctx.AllINT())))\n");
 		grammarBuilder.append("	} else {\n");
 		grammarBuilder.append("		fmt.Println(ctx.ID().GetSymbol())\n");
 		grammarBuilder.append("	}\n");

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParseTrees.java
@@ -193,7 +193,7 @@ public class TestParseTrees extends BaseTest {
 	@Test
 	public void testTokenAndRuleContextString() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(167);
+		StringBuilder grammarBuilder = new StringBuilder(195);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s\n");
 		grammarBuilder.append("@init {\n");
@@ -204,7 +204,7 @@ public class TestParseTrees extends BaseTest {
 		grammarBuilder.append("}\n");
 		grammarBuilder.append("  : r=a ;\n");
 		grammarBuilder.append("a : 'x' { \n");
-		grammarBuilder.append("fmt.Println(p.GetRuleInvocationStack(nil))\n");
+		grammarBuilder.append("fmt.Println(antlr.PrintJavaStringArray(p.GetRuleInvocationStack(nil)))\n");
 		grammarBuilder.append("} ;");
 		String grammar = grammarBuilder.toString();
 		String input ="x";

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParseTrees.java
@@ -193,7 +193,7 @@ public class TestParseTrees extends BaseTest {
 	@Test
 	public void testTokenAndRuleContextString() throws Exception {
 		mkdir(parserpkgdir);
-		StringBuilder grammarBuilder = new StringBuilder(195);
+		StringBuilder grammarBuilder = new StringBuilder(194);
 		grammarBuilder.append("grammar T;\n");
 		grammarBuilder.append("s\n");
 		grammarBuilder.append("@init {\n");

--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParseTrees.java
+++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/go/TestParseTrees.java
@@ -204,7 +204,7 @@ public class TestParseTrees extends BaseTest {
 		grammarBuilder.append("}\n");
 		grammarBuilder.append("  : r=a ;\n");
 		grammarBuilder.append("a : 'x' { \n");
-		grammarBuilder.append("fmt.Println(antlr.PrintJavaStringArray(p.GetRuleInvocationStack(nil)))\n");
+		grammarBuilder.append("fmt.Println(antlr.PrintArrayJavaStyle(p.GetRuleInvocationStack(nil)))\n");
 		grammarBuilder.append("} ;");
 		String grammar = grammarBuilder.toString();
 		String input ="x";

--- a/runtime/Go/antlr/utils.go
+++ b/runtime/Go/antlr/utils.go
@@ -6,9 +6,7 @@ import (
 	"hash/fnv"
 	"sort"
 	"strings"
-	//	"regexp"
-	//	"bytes"
-	//	"encoding/gob"
+	"bytes"
 	"strconv"
 )
 
@@ -341,6 +339,25 @@ func EscapeWhitespace(s string, escapeSpaces bool) string {
 		s = strings.Replace(s, " ", "\u00B7", -1)
 	}
 	return s
+}
+
+// Prints a Java style string array
+
+func PrintJavaStringArray(sa []string) string {
+	var buffer bytes.Buffer
+
+	buffer.WriteString("[")
+
+	for i, s := range sa {
+		buffer.WriteString(s)
+		if i != len(sa)-1 {
+			buffer.WriteString(", ")
+		}
+	}
+
+	buffer.WriteString("]")
+
+	return buffer.String()
 }
 
 func TitleCase(str string) string {

--- a/runtime/Go/antlr/utils.go
+++ b/runtime/Go/antlr/utils.go
@@ -341,9 +341,17 @@ func EscapeWhitespace(s string, escapeSpaces bool) string {
 	return s
 }
 
-// Prints a Java style string array
+func TerminalNodeToStringArray(sa []TerminalNode) []string {
+	st := make([]string, len(sa))
 
-func PrintJavaStringArray(sa []string) string {
+	for i, s := range sa {
+		st[i] = fmt.Sprintf("%v", s)
+	}
+
+	return st
+}
+
+func PrintArrayJavaStyle(sa []string) string {
 	var buffer bytes.Buffer
 
 	buffer.WriteString("[")


### PR DESCRIPTION
Should fix at least 2 tests associated with the issue identified in #47.

Thanks @sridharxp! Note, this requires some changes to the go runtime test templates, not just the output.
